### PR TITLE
Add support for Lark bot with signature verification settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,6 @@ DockerHub: https://hub.docker.com/r/gaoliang/synology-dsm-notification-lark
 docker run -d -p 10080:8080 -e LARK_WEBHOOK_URL=https://replace.with.your.lark.custom.bot.webbhook.url gaoliang/synology-dsm-notification-lark
 ```
 
+> If you setup your bot with [signature verification](https://open.larksuite.com/document/uAjLw4CM/ukTMukTMukTM/bot-v3/use-custom-bots-in-a-group#348211be), you can pass your keystore through `LARK_SECRET` param.
+
 2. config DSM notification webhook, set webhook url to POST http://localhost:10080/lark and add a `content` field in http body.

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ var LarkSecret string
 
 func init() {
 	LarkWebhookUrl = os.Getenv("LARK_WEBHOOK_URL")
-	LarkSecret = os.Getenv("LARK_CRYPT_KEY")
+	LarkSecret = os.Getenv("LARK_SECRET")
 
 	_, err := url.ParseRequestURI(LarkWebhookUrl)
 	if err != nil {


### PR DESCRIPTION
Modified the `main.go` for users who want to use lark bot with Signature verification, they may want a Docker param to accept the `secret key` and the image can generate `signature` when sending reuqest to Lark like it just works.

Test: Create a lark group and add a Webhook bot. Use "Kaywords" and "Signature verification" as bot settings respectively, and then verify the availability of this image.